### PR TITLE
Make the callback module configurable in the application environment

### DIFF
--- a/src/gettext.erl
+++ b/src/gettext.erl
@@ -46,6 +46,7 @@
          , team/0
          , org_name/0
          , copyright/0
+         , callback_mod/0
          , write_pretty/2
          , get_language_name/1
         ]).
@@ -368,6 +369,9 @@ org_name() ->
 copyright() ->
     get_app_key(copyright, "YYYY Organization").
     
+callback_mod() ->
+    get_app_key(callback_mod, gettext_server).
+
 
 
 mk_polish_style_header(LC) ->

--- a/src/gettext_sup.erl
+++ b/src/gettext_sup.erl
@@ -52,7 +52,7 @@ start_link(Options) ->
 %%          {error, Reason}   
 %%----------------------------------------------------------------------
 init([]) ->
-    init([gettext_server]);  % just a default that should always work
+    init([gettext:callback_mod()]);  % just a default that should always work
 init([CallBackMod]) ->
     GettextServer = {gettext_server,{gettext_server,start_link,[CallBackMod]},
 	      permanent,5000,worker,[gettext_server]},


### PR DESCRIPTION
I've modified `gettext.erl` too add the function `callback_mod/0` that tries to get the name of the callback module from the application's environment and defaults to `gettext_server` if the configuration key has not been set. I also changed `gettext_sup.erl` to use this function when initializing the supervisor instead of hardcoding the value of the callback module.

The reason for this change was to be able to set the _gettext_ directory and default language from the `app.config` file of the application that uses _gettext_ instead of having to use environment variables from the OS shell or having to directly instantiate _gettext's_ supervisor from my application.

Please let me know if you need me to make additional changes to accept this patch.
