### PR TITLE
Fix makefile to work with multiple jobs

### DIFF
--- a/src/gettext_server.erl
+++ b/src/gettext_server.erl
@@ -88,7 +88,7 @@ gettext_def_lang() ->
 %% Description: Starts the server
 %%--------------------------------------------------------------------
 start_link() ->
-    start_link(?MODULE).
+    start_link({?MODULE, application:get_all_env()}).
 
 start_link(CallBackMod) ->
     start_link(CallBackMod, ?SERVER).

--- a/src/gettext_server.erl
+++ b/src/gettext_server.erl
@@ -88,24 +88,30 @@ gettext_def_lang() ->
 %% Description: Starts the server
 %%--------------------------------------------------------------------
 start_link() ->
-    start_link({?MODULE, application:get_all_env()}).
+    start_link({?MODULE, application:get_all_env()}, ?SERVER).
 
-start_link(CallBackMod) ->
-    start_link(CallBackMod, ?SERVER).
+start_link(CallBackMod) when is_atom(CallBackMod) ->
+    start_link({CallBackMod, application:get_all_env()}, ?SERVER);
 
-start_link(CallBackMod, Name) ->
-    gen_server:start_link({local, Name}, ?MODULE, [CallBackMod, Name],[]).
+start_link(Config) when is_list(Config) ->
+    start_link({?MODULE, Config}, ?SERVER).
+
+start_link({CallBackMod, Config}, Name) ->
+    gen_server:start_link({local, Name}, ?MODULE, [{CallBackMod, Config}, Name], []).
 
 %%--------------------------------------------------------------------
 
 start() ->
-    start({?MODULE, application:get_all_env()}).
+    start({?MODULE, application:get_all_env()}, ?SERVER).
 
-start(CallBackMod) ->
-    start(CallBackMod, ?SERVER).
+start(CallBackMod) when is_atom(CallBackMod) ->
+    start({CallBackMod, application:get_all_env()}, ?SERVER);
 
-start(CallBackMod, Name) ->
-    gen_server:start({local, Name}, ?MODULE, [CallBackMod, Name], []).
+start(Config) when is_list(Config) ->
+    start({?MODULE, Config}, ?SERVER).
+
+start({CallBackMod, Config}, Name) ->
+    gen_server:start({local, Name}, ?MODULE, [{CallBackMod, Config}, Name], []).
 
 %%====================================================================
 %% Server functions

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ clean:
 ../ebin/%.beam: %.erl $(INCLUDES) Makefile
 	erlc -pa ../ebin -o ../ebin $(ERLC_FLAGS) +gettext $<
 
-test:
+test: $(EBIN_FILES) pot
 	@erl -pa ../ebin -noshell \
 	  -eval 'gettext_demo:hello_world()' \
 	  -s init stop


### PR DESCRIPTION
A fairly trivial little fix, but hopefully it will save someone else having to figure out why their make was failing on the first try :)

Running a straight 'make all' with -j >1 can fail because the 'test'
target is in fact dependent on the pot and beam files being built, but
wasn't flagged as such. This fixes that.
