### PR TITLE
CallbackMod never called

### DIFF
--- a/src/gettext_server.erl
+++ b/src/gettext_server.erl
@@ -246,12 +246,12 @@ get_gettext_dir(CallBackMod, Config) ->
 
 get_gettext_dir(CallBackMod) ->
     case gettext_compile:get_env(path) of
-	undefined ->
-	    try CallBackMod:gettext_dir()
-	    catch
-		_:_ -> gettext_dir() % fallback
-	    end;
-	Dir -> Dir
+      "." ->
+        try CallBackMod:gettext_dir()
+        catch
+        _:_ -> "." % fallback
+        end;
+      Dir -> Dir
     end.
 
 get_default_lang(CallBackMod, Config) ->
@@ -262,12 +262,12 @@ get_default_lang(CallBackMod, Config) ->
 
 get_default_lang(CallBackMod) ->
     case gettext_compile:get_env(lang) of
-	undefined ->
-	    case catch CallBackMod:gettext_def_lang() of
-		Dir when is_list(Dir) -> Dir;
-		_ -> gettext_def_lang() % fallback
-	    end;
-	DefLang -> DefLang
+      ?DEFAULT_LANG ->
+        case catch CallBackMod:gettext_def_lang() of
+          Dir when is_list(Dir) -> Dir;
+          _ -> ?DEFAULT_LANG % fallback
+        end;
+      DefLang -> DefLang
     end.
 
 db_filename(TableName, GettextDir) ->


### PR DESCRIPTION
Due changes in commit 9c3122c9aba0e9908b437f3cee9856d14ea59778 setting
default return values for gettext_compile:get_env/1 the callback is
never called. It expects the function returns undefined.

Changed undefined to default values.
