### PR TITLE
Add clause to pt for key2str/2 calls

### DIFF
--- a/src/gettext_compile.erl
+++ b/src/gettext_compile.erl
@@ -261,6 +261,11 @@ pt([{call,_,{remote,_,{atom,_,gettext},{atom,_,key2str}},
     ?debug( "++++++ String=<~p>~n",[String]),
     dump(String, L5),
     [H | pt(T, Opts, Func)];
+pt([{call,_,{remote,_,{atom,_,gettext},{atom,_,key2str}},
+    [{string,L5,String},_]} = H | T], Opts, Func) ->
+    ?debug( "++++++ String=<~p>~n",[String]),
+    dump(String, L5),
+    [H | pt(T, Opts, Func)];
 %%% Retrieve module name from parametrized modules
 pt([{attribute,L,module,{Mod,_Params}} | T], Opts, Func) ->
     pt([{attribute,L,module,Mod} | T], Opts, Func);


### PR DESCRIPTION
WIthout this additional clause:
`-define(TXT(S), gettext:key2str(S)).` matchs so a new message is generated in the .po file
`-define(TXT2(S, Lang), gettext:key2str(S, Lang)).` doesn't match, no message detected

This fix allows us to benefit from the TXT2 macro in order to override the locale during a HTTP request for instance.
``` erlang
?TXT2("My message", i18n:get_locale_from_cookie(Cookie))
```
It avoids constructs such as:
``` erlang
put(gettext_language, i18n:get_locale_from_cookie(Cookie)),
?TXT("My message")
```


